### PR TITLE
ci: Renovate runs go mod tidy after update

### DIFF
--- a/renovate-default.json
+++ b/renovate-default.json
@@ -24,6 +24,7 @@
     "after 10am on saturday",
     "on sunday"
   ],
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
@james-munson and I noticed in https://github.com/longhorn/longhorn-share-manager/pull/205 that Renovate is updating dependencies, but not running `go mod tidy` afterwards. In that PR, I only added a comment to a `go.mod` file, then ran `go mod tidy` as a matter of course. The `go mod tidy` removed many hashes from the `go.sum` file that Renovate had left there.

Renovate can be configured to run a `go mod tidy` itself: 

- https://docs.renovatebot.com/golang/#module-tidying
- https://docs.renovatebot.com/configuration-options/#postupdateoptions

Apparently it doesn't by default because the `go mod tidy` may make changes to `go.mod` or `go.sum` that are unrelated to its actual work. (For example, if a developer forgot to run `go mod tidy` previously, Renovate's `go mod tidy` would remove hashes from the `go.sum` that the developer should have removed before merging.)

We think it is a good idea to enable the option for Renovate. We can revert it if it causes confusion.