### PR TITLE
fix(patch digest): blaock lasso update for v1.5.x and v1.6.x

### DIFF
--- a/renovate-default.json
+++ b/renovate-default.json
@@ -99,6 +99,18 @@
     },
     {
       "matchBaseBranches": [
+        "/^v\\d+\\.\\d+\\.x/"
+      ],
+      "matchPackageNames": [
+        "github.com/rancher/lasso"
+      ],
+      "matchManagers": [
+        "gomod"
+      ],
+      "enabled": false
+    },
+    {
+      "matchBaseBranches": [
         "master",
         "main"
       ],


### PR DESCRIPTION
updating lasso will lead to k8s.io updated
block the updating for v1.5.x and v1.6.x
