### PR TITLE
fix: change log level error for changelog

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -135,6 +135,7 @@ jobs:
       name: Create a changelog from the last release
       run: |
         output=$(renote changelog \
+          --log-level error \
           --owner longhorn \
           --branch ${{ steps.var.outputs.branch }} \
           --tag ${{ steps.var.outputs.tag }} \

--- a/.github/workflows/release-sprint.yml
+++ b/.github/workflows/release-sprint.yml
@@ -91,6 +91,7 @@ jobs:
       name: Create a changelog from the last release
       run: |
         output=$(renote changelog \
+          --log-level error \
           --owner longhorn \
           --branch ${{ steps.var.outputs.branch }} \
           --tag ${{ steps.var.outputs.tag }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
       name: Create a changelog from the last release
       run: |
         output=$(renote changelog \
+          --log-level error \
           --owner longhorn \
           --branch ${{ steps.var.outputs.branch }} \
           --prev-tag ${{ steps.var.outputs.prev_tag }} \


### PR DESCRIPTION
Prevent logs in the sprint release note. 

![image](https://github.com/user-attachments/assets/b1ed4038-d6b3-4ca7-96df-1f8f3c978db7)
