### PR TITLE
fix(release): remove "--tag ..." from changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,6 @@ jobs:
           --log-level error \
           --owner longhorn \
           --branch "${{ steps.var.outputs.branch }}" \
-          --tag "${{ steps.var.outputs.tag }}" \
           --prev-tag "${{ steps.var.outputs.prev_tag }}" \
           $(printf -- '--repos %s ' "${repos[@]}"))
         echo "$output"


### PR DESCRIPTION
Fix the regression in https://github.com/longhorn/release/commit/8c83428e3ecbe18e083c95f3470d6b385028264f. The option is not required for the release workflow.