### PR TITLE
chore(renovate): disable longhorn/types update for v1.7.x and v1.6.x

### DIFF
--- a/renovate-default.json
+++ b/renovate-default.json
@@ -212,6 +212,28 @@
         "gomod"
       ],
       "groupName": "longhorn branch repo dependencies"
+    },
+    {
+      "matchBaseBranches": [
+        "v1.7.x",
+        "v1.6.x"
+      ],
+      "matchPackageNames": [
+        "github.com/longhorn/types"
+      ],
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchPackagePatterns": [
+        "^github.com/longhorn/longhorn-engine$",
+        "^github.com/longhorn/longhorn-instance-manager$",
+        "^github.com/longhorn/longhorn-share-manager$",
+        "^github.com/longhorn/backing-image-manager$"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
gRPC methods have breaking changes in v1.8.x.