### PR TITLE
chore: start renovate update after building sprint images

### DIFF
--- a/.github/workflows/release-sprint.yml
+++ b/.github/workflows/release-sprint.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
   schedule:
-    - cron: '0 1 * * 0' # every Sunday at 01:00
+    - cron: '0 1 * * 0' # every Sunday at 01:00 UTC (Asia/Taipei 09:00)
 
 defaults:
   run:

--- a/renovate-default.json
+++ b/renovate-default.json
@@ -23,8 +23,7 @@
   "prHourlyLimit": 12,
   "timezone": "Asia/Taipei",
   "schedule": [
-    "after 10am on saturday",
-    "on sunday"
+    "after 1pm on sunday"
   ],
   "postUpdateOptions": ["gomodTidy"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
- To avoid failures of building sprint images, start renovate update after building sprint images.
  - sprint image build at Asia/Taipei 9am
  - renovate update at Asia/Taipei 1pm

- Only update dependencies on Sunday. No need to trigger the updates too frequently.

Longhorn/longhorn#10559