### PR TITLE
chore: disable renovate update and sprint release for v1.8.x

### DIFF
--- a/.github/workflows/release-sprint.yml
+++ b/.github/workflows/release-sprint.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        branch_tag: ['master:v1.11.0, v1.10.x:v1.10.2', 'v1.9.x:v1.9.3', 'v1.8.x:v1.8.3']
+        branch_tag: ['master:v1.11.0, v1.10.x:v1.10.2', 'v1.9.x:v1.9.3']
 
     steps:
     - name: Install dependencies

--- a/renovate-default.json
+++ b/renovate-default.json
@@ -8,8 +8,7 @@
     "master",
     "main",
     "v1.10.x",
-    "v1.9.x",
-    "v1.8.x"
+    "v1.9.x"
   ],
   "automergeMajor": false,
   "dockerfile": {
@@ -191,23 +190,6 @@
         "github.com/longhorn/cli"
       ],
       "allowedVersions": "/^v1\\.9\\.\\S+/",
-      "matchManagers": [
-        "gomod"
-      ],
-      "groupName": "longhorn branch repo dependencies"
-    },
-    {
-      "matchBaseBranches": [
-        "v1.8.x"
-      ],
-      "matchPackageNames": [
-        "github.com/longhorn/longhorn-engine",
-        "github.com/longhorn/longhorn-instance-manager",
-        "github.com/longhorn/longhorn-share-manager",
-        "github.com/longhorn/backing-image-manager",
-        "github.com/longhorn/cli"
-      ],
-      "allowedVersions": "/^v1\\.8\\.\\S+/",
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
We will focus on v1.9, v1.10 and master.