### PR TITLE
chore: add minimumReleaseAge to Renovate config

### DIFF
--- a/renovate-default.json
+++ b/renovate-default.json
@@ -31,6 +31,9 @@
   },
   "packageRules": [
     {
+      "minimumReleaseAge": "2 weeks"
+    },
+    {
       "matchUpdateTypes": [
         "major"
       ],

--- a/renovate-lib.json
+++ b/renovate-lib.json
@@ -27,6 +27,9 @@
   },
   "packageRules": [
     {
+      "minimumReleaseAge": "2 weeks"
+    },
+    {
       "matchUpdateTypes": [
         "major",
         "minor"


### PR DESCRIPTION
chore(renovate): add minimumReleaseAge of 2 weeks to prevent adopting yanked or broken package releases

Signed-off-by: David Ko <dko@suse.com>